### PR TITLE
Add `connect` function to pool to auto release the connection after used

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ A new connection pool using default connection configurations (`host="localhost"
     pool.release(conn)          #put back connection to the pool
     pool.release_pool()         #release pool (close rethinkdb connections)
 
+    # ...
+    with pool.connect() as conn1:
+        # do something with conn1
+    # pool.release(conn1) is automatically called after leaving the with code block
+
+
 
 Optional arguments
 ------------------

--- a/repool/pool.py
+++ b/repool/pool.py
@@ -159,3 +159,26 @@ class ConnectionPool(object):
                 logger.exception(e)
                 pass
         logger.debug("Cleanup thread ending")
+
+    def connect(self, timeout=None):
+        '''Acquire a new connection with `with` statement and auto release the connection after
+            go out the with block
+
+        :param timeout: @see #aquire
+        :returns: Returns a RethinkDB connection
+        :raises Empty: No resources are available before timeout.
+        '''
+        return self.__F__(self, timeout)
+
+    class __F__:
+        def __init__(self, pool, timeout=None):
+            self.pool = pool
+            self.timeout = timeout
+
+        def __enter__(self):
+            self.conn = self.pool.acquire(self.timeout)
+            return self.conn
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            if self.conn:
+                self.pool.release(self.conn)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -17,11 +17,11 @@
 import unittest
 from unittest.mock import patch
 from unittest.mock import MagicMock
-#import logging
+# import logging
 from repool import ConnectionPool, ConnectionWrapper
 
 
-#logging.basicConfig(level="DEBUG")
+# logging.basicConfig(level="DEBUG")
 
 class TestPool(unittest.TestCase):
     @patch('repool.pool.r')
@@ -55,7 +55,7 @@ class TestPool(unittest.TestCase):
         nb_init = p._pool.qsize()
         conn = p.acquire()
         nb_term = p._pool.qsize()
-        self.assertEqual(nb_init-1, nb_term)
+        self.assertEqual(nb_init - 1, nb_term)
         p.release(conn)
         p.release_pool()
 
@@ -81,3 +81,14 @@ class TestPool(unittest.TestCase):
         p.release(conn1)
         with self.assertRaises(PoolException):
             p.release_pool()
+
+    @patch('repool.pool.r')
+    def test_connect(self, mock_r):
+        mock_r.connect = MagicMock()
+        mock_r.close = MagicMock()
+        from repool.pool import ConnectionPool
+        p = ConnectionPool(pool_size=1)
+        with p.connect() as conn:
+            self.assertEqual(0, p._pool.qsize())
+        self.assertEqual(1, p._pool.qsize())
+        p.release_pool()


### PR DESCRIPTION
I somehow usually forget to release the connection after use. So, I make this to release the connection after finishing the use. It works like the file opening (`with open(filename) as f:`)
